### PR TITLE
Switch to GHCR and add main branch protection

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -3,12 +3,15 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code
@@ -17,11 +20,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -29,7 +33,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/from-code-to-cloud:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/from-code-to-cloud:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/from-code-to-cloud:latest
+            ghcr.io/${{ github.repository_owner }}/from-code-to-cloud:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Switched Docker image registry from Docker Hub to GitHub Container Registry (ghcr.io)
- Uses `GITHUB_TOKEN` for auth — no external secrets needed
- Added `packages: write` permission to the workflow job
- Fixed workflow trigger branch from `master` to `main`
- Images published as `ghcr.io/jmcglock/from-code-to-cloud:latest` and `:<sha>`

## Test plan
- [ ] Confirm workflow runs and image appears in GitHub Packages after merge
- [ ] Verify branch protection rules are active on `main`